### PR TITLE
[database] | feat(entity): 각 table내 count 및 popularity 컬럼 추가

### DIFF
--- a/packages/typeorm/src/entity/comment.entity.ts
+++ b/packages/typeorm/src/entity/comment.entity.ts
@@ -5,11 +5,17 @@ import {
   ManyToOne,
   JoinColumn,
   ManyToMany,
+  BeforeInsert,
 } from 'typeorm';
 
 import { Base } from './base.entity';
 import { User } from './user.entity';
 import { Video } from './video.entity';
+
+const popularityWeight = {
+  childrenCount: 4,
+  likedUsersCount: 1,
+};
 
 @Entity({
   name: 'comments',
@@ -22,17 +28,29 @@ export class Comment extends Base {
   })
   public content: string;
 
-  @ManyToMany(
-    type => User,
-    user => user.likedComments,
-  )
-  public likedUsers: User[];
+  @Column({
+    name: 'likedUsersCount',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public likedUsersCount: number;
 
-  @OneToMany(
-    type => Comment,
-    comment => comment.parent,
-  )
-  public children: Comment[];
+  @Column({
+    name: 'childrenCount',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public childrenCount: number;
+
+  @Column({
+    name: 'popularity',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public popularity: number;
 
   @ManyToOne(
     type => Comment,
@@ -61,4 +79,23 @@ export class Comment extends Base {
     },
   )
   public video: Video;
+
+  @ManyToMany(
+    type => User,
+    user => user.likedComments,
+  )
+  public likedUsers: User[];
+
+  @OneToMany(
+    type => Comment,
+    comment => comment.parent,
+  )
+  public children: Comment[];
+
+  @BeforeInsert()
+  public updatePopularity() {
+    this.popularity =
+      this.childrenCount * popularityWeight.childrenCount +
+      this.likedUsersCount * popularityWeight.likedUsersCount;
+  }
 }

--- a/packages/typeorm/src/entity/tag.entity.ts
+++ b/packages/typeorm/src/entity/tag.entity.ts
@@ -14,6 +14,14 @@ export class Tag extends Base {
   })
   public name: string;
 
+  @Column({
+    name: 'videosCount',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public videosCount: number;
+
   @ManyToMany(
     type => Video,
     video => video.tags,

--- a/packages/typeorm/src/entity/user.entity.ts
+++ b/packages/typeorm/src/entity/user.entity.ts
@@ -51,9 +51,17 @@ export class User extends Base {
   })
   public githubId: string;
 
+  @Column({
+    name: 'videosCount',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public videosCount: number;
+
   @ManyToMany(
-    type => Video,
-    video => video.likedUsers,
+    type => Comment,
+    comment => comment.likedUsers,
   )
   @JoinTable({
     name: 'liked_comments',

--- a/packages/typeorm/src/entity/video.entity.ts
+++ b/packages/typeorm/src/entity/video.entity.ts
@@ -6,12 +6,19 @@ import {
   OneToMany,
   ManyToOne,
   JoinTable,
+  BeforeInsert,
 } from 'typeorm';
 
 import { Base } from './base.entity';
 import { Tag } from './tag.entity';
 import { User } from './user.entity';
 import { Comment } from './comment.entity';
+
+const popularityWeight = {
+  views: 1,
+  likedUsersCount: 2,
+  commentsCount: 4,
+};
 
 @Entity({
   name: 'videos',
@@ -34,20 +41,20 @@ export class Video extends Base {
   public description: string;
 
   @Column({
-    name: 'like',
+    name: 'likedUsersCount',
     type: 'int',
     nullable: false,
     default: 0,
   })
-  public like: number;
+  public likedUsersCount: number;
 
   @Column({
-    name: 'hit',
+    name: 'views',
     type: 'int',
     nullable: false,
     default: 0,
   })
-  public hit: number;
+  public views: number;
 
   @Column({
     name: 'sourceUrl',
@@ -71,6 +78,22 @@ export class Video extends Base {
     nullable: false,
   })
   public playtime: Timestamp;
+
+  @Column({
+    name: 'commentsCount',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public commentsCount: number;
+
+  @Column({
+    name: 'popularity',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  public popularity: number;
 
   @ManyToOne(
     type => User,
@@ -109,4 +132,12 @@ export class Video extends Base {
     comment => comment.video,
   )
   public comments: Comment;
+
+  @BeforeInsert()
+  public updatePopularity() {
+    this.popularity =
+      this.likedUsersCount * popularityWeight.likedUsersCount +
+      this.views * popularityWeight.views +
+      this.commentsCount * popularityWeight.commentsCount;
+  }
 }


### PR DESCRIPTION
One to Many, Many to Many 관계에서 매번 Join을 통해 갯수를 확인하지 않도록 컬럼에 갯수 항목들을 추가하였습니다. 또, 이러한 갯수를 통해 대상의 인기도를 평가하는 컬럼을 추가하였습니다.