### PR TITLE
비디오 리스트 관련 기능 추가

### DIFF
--- a/packages/client/components/AppBar/index.tsx
+++ b/packages/client/components/AppBar/index.tsx
@@ -40,7 +40,7 @@ export const AppBar: React.FunctionComponent<AppBarProps> = ({ maxWidth }) => {
           </Link>
 
           <button onClick={handleSearchBar}>
-            <SearchSVG width={23} height={24} />
+            <SearchSVG width={24} height={24} />
           </button>
 
           <Link href={routePath.login}>

--- a/packages/client/components/AppBar/index.tsx
+++ b/packages/client/components/AppBar/index.tsx
@@ -12,7 +12,7 @@ interface AppBarProps {
   maxWidth?: number;
 }
 
-export const AppBar: React.FunctionComponent<AppBarProps> = ({ maxWidth }) => {
+export const AppBar: React.FunctionComponent<AppBarProps> = () => {
   const [isSearchBarActive, setSearchBarActive] = useState(false);
 
   const handleSearchBar = () => {
@@ -21,7 +21,7 @@ export const AppBar: React.FunctionComponent<AppBarProps> = ({ maxWidth }) => {
 
   return (
     <S.AppBar>
-      <S.Container maxWidth={maxWidth}>
+      <S.Container>
         <S.Logo isSearchBarActive={isSearchBarActive}>
           <Link href="/">
             <a>

--- a/packages/client/components/AppBar/styles.tsx
+++ b/packages/client/components/AppBar/styles.tsx
@@ -23,15 +23,6 @@ export const Container = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  @media only screen and (min-width: ${BREAKPOINT}px) {
-    ${props =>
-      props.maxWidth &&
-      `
-      max-width: ${props.maxWidth}px;
-      margin: 0 auto;
-      padding: 0;
-    `}
-  }
 `;
 
 export const Content = styled.div``;

--- a/packages/client/components/AppBar/styles.tsx
+++ b/packages/client/components/AppBar/styles.tsx
@@ -41,16 +41,16 @@ export const Logo = styled.div`
   display: ${props => (props.isSearchBarActive ? 'none' : 'block')};
 
   @media only screen and (min-width: ${BREAKPOINT}px) {
+    flex: 1;
+    margin-left: 1.3rem;
     display: block;
   }
+
   svg {
     height: 3rem;
-  }
+    vertical-align: middle;
 
-  @media only screen and (min-width: ${BREAKPOINT}px) {
-    margin-left: 1.3rem;
-
-    svg {
+    @media only screen and (min-width: ${BREAKPOINT}px) {
       height: 3.6rem;
     }
   }
@@ -77,8 +77,12 @@ export const DesktopButtons = styled.div`
   display: none;
 
   @media only screen and (min-width: ${BREAKPOINT}px) {
+    flex: 1;
     display: block;
+    display: flex;
+    justify-content: flex-end;
   }
+
   a {
     button {
       user-select: none;

--- a/packages/client/components/Filters/index.tsx
+++ b/packages/client/components/Filters/index.tsx
@@ -3,30 +3,30 @@ import React from 'react';
 import * as S from './styles';
 
 interface FiltersProps {
-  filters: string[];
-  activeFilter: string;
-  onClick: (filter: string) => void;
+  filters: Array<{ label: string; value: string }>;
+  activeValue: string;
+  onClick: (value: string) => void;
 }
 
 const Filters: React.FunctionComponent<FiltersProps> = ({
   filters,
-  activeFilter,
+  activeValue,
   onClick,
   ...rest
 }) => {
   return (
     <S.Filters {...rest}>
-      {filters.map(filter => {
-        const className = activeFilter === filter ? 'active' : '';
+      {filters.map(({ label, value }) => {
+        const className = activeValue === value ? 'active' : '';
         return (
           <li
-            key={filter}
+            key={value}
             className={className}
             onClick={() => {
-              onClick(filter);
+              onClick(value);
             }}
           >
-            {filter}
+            {label}
           </li>
         );
       })}

--- a/packages/client/components/Layout/index.tsx
+++ b/packages/client/components/Layout/index.tsx
@@ -21,7 +21,7 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
 
   return (
     <S.Layout>
-      <AppBar maxWidth={maxWidth} />
+      <AppBar />
       {drawer && <Drawer />}
       <Content maxWidth={maxWidth}>{children}</Content>
     </S.Layout>

--- a/packages/client/components/SearchBar/index.tsx
+++ b/packages/client/components/SearchBar/index.tsx
@@ -32,7 +32,7 @@ export const SearchBar: React.FunctionComponent<SearchBarProps> = ({
       </S.ArrowBack>
 
       <S.Input isActive={isActive}>
-        <SearchSVG width={20} height={20} viewBox={'0, 0, 20, 20'} />
+        <SearchSVG width={20} height={20} viewBox="0 0 24 24" />
         <input type="text" placeholder="검색" onKeyPress={sendQuery} />
       </S.Input>
     </>

--- a/packages/client/components/SearchBar/styles.tsx
+++ b/packages/client/components/SearchBar/styles.tsx
@@ -16,24 +16,41 @@ export const Input = styled.div`
   height: 3.2rem;
   background-color: #484c50;
   border-radius: 0.5rem;
-  padding-left: 1rem;
   align-items: center;
+  position: relative;
   display: ${props => (props.isActive ? 'flex' : 'none')};
+  padding-left: 4rem;
+  padding-right: 2rem;
+
   @media only screen and (min-width: ${BREAKPOINT}px) {
-    display: flex;
-    width: 28rem;
+    display: block;
+    max-width: 28rem;
+    flex: 1;
+    padding-left: 4.3rem;
+    padding-right: 2rem;
   }
+
   svg {
+    position: absolute;
+    left: 1rem;
+    top: calc(50% - 10px);
     vertical-align: middle;
+
+    @media only screen and (min-width: ${BREAKPOINT}px) {
+      left: 1.3rem;
+    }
   }
+
   input {
+    border-radius: 0.5rem;
     width: 100%;
+    height: 100%;
     background-color: #484c50;
     vertical-align: middle;
     font-size: 1.6rem;
-    margin-left: 1rem;
     color: white;
     border: none;
     outline: none;
+    padding: 0;
   }
 `;

--- a/packages/client/components/VideoItem/index.tsx
+++ b/packages/client/components/VideoItem/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
+import { format } from '../../libs/timeago';
+
 import * as S from './styles';
 import { parsePlaytime } from '../../libs/parsePlaytime';
 
@@ -63,7 +65,7 @@ const VideoItem = ({
           <S.Additionals>
             <span>조회 수 {views}</span>
             <span> · </span>
-            <span>{3}일전</span>
+            <span>{format(createdAt, 'ko')}</span>
           </S.Additionals>
         </S.Info>
       </S.Details>

--- a/packages/client/components/VideoItem/index.tsx
+++ b/packages/client/components/VideoItem/index.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 import * as S from './styles';
-import Link from 'next/link';
-import { useRouter } from 'next/dist/client/router';
+import { parsePlaytime } from '../../libs/parsePlaytime';
 
 const VideoItem = ({
   id,
   title,
-  description,
-  like,
-  hit,
-  sourceUrl,
+  views,
   thumbnail,
   playtime,
+  createdAt,
   user,
-  tags,
-  likedUsers,
-  comments,
   showUser = true,
   mobileType = 'vertical',
   desktopType = 'vertical',
@@ -37,6 +33,7 @@ const VideoItem = ({
         <a onClick={e => e.stopPropagation()}>
           <S.Thumbnail mobileType={mobileType} desktopType={desktopType}>
             <img src={thumbnail} />
+            <div>{parsePlaytime(playtime)}</div>
           </S.Thumbnail>
         </a>
       </Link>
@@ -64,7 +61,7 @@ const VideoItem = ({
             </Link>
           )}
           <S.Additionals>
-            <span>조회 수 {hit}</span>
+            <span>조회 수 {views}</span>
             <span> · </span>
             <span>{3}일전</span>
           </S.Additionals>

--- a/packages/client/components/VideoItem/styles.tsx
+++ b/packages/client/components/VideoItem/styles.tsx
@@ -102,6 +102,20 @@ export const Thumbnail = styled.div`
     width: 100%;
     margin: auto;
   }
+
+  div {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    font-size: 1.2rem;
+    padding: 0 0.5rem;
+    color: white;
+    font-weight: 700;
+    background: rgba(0, 0, 0, 0.7);
+    border-radius: 0.3rem;
+    height: 2.3rem;
+    line-height: 2.3rem;
+  }
 `;
 
 export const Details = styled.div`

--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -18,6 +18,32 @@ export const routePath = {
   login: '/auth/login',
 };
 
+export const periods = {
+  week: 'week',
+  month: 'month',
+  year: 'year',
+  all: 'all',
+};
+
+export const hotlistFilters = [
+  {
+    label: '일주일',
+    value: periods.week,
+  },
+  {
+    label: '한달',
+    value: periods.month,
+  },
+  {
+    label: '일년',
+    value: periods.year,
+  },
+  {
+    label: '전체',
+    value: periods.all,
+  },
+];
+
 export const fontWeight = {
   regular: 400,
   bold: 700,

--- a/packages/client/libs/fetch.ts
+++ b/packages/client/libs/fetch.ts
@@ -1,0 +1,11 @@
+import isomorphicUnfetch from 'isomorphic-unfetch';
+
+export const fetch = async (input: RequestInfo, init?: RequestInit) => {
+  const res = await isomorphicUnfetch(input, init);
+
+  if (!res.ok) {
+    throw Error(res.statusText);
+  }
+
+  return await res.json();
+};

--- a/packages/client/libs/parsePlaytime.ts
+++ b/packages/client/libs/parsePlaytime.ts
@@ -1,0 +1,37 @@
+const parseHours = (hours: number) => {
+  if (hours === 0) {
+    return '';
+  }
+
+  return `${hours}:`;
+};
+
+const parseMinutes = (minutes: number, hours: number) => {
+  if (minutes < 10 && hours !== 0) {
+    return `0${minutes}:`;
+  }
+
+  return `${minutes}:`;
+};
+
+const parseSeconds = (seconds: number) => {
+  if (seconds < 10) {
+    return `0${seconds}`;
+  }
+
+  return `${seconds}`;
+};
+
+export const parsePlaytime = (playtime: string) => {
+  const [hourSegment, minuteSegment, secondSegment] = playtime.split(':');
+
+  const parsedHours = parseInt(hourSegment, 10);
+  const parsedMinute = parseInt(minuteSegment, 10);
+  const parsedSecond = parseInt(secondSegment, 10);
+
+  const hours = parseHours(parsedHours);
+  const minutes = parseMinutes(parsedMinute, parsedHours);
+  const seconds = parseSeconds(parsedSecond);
+
+  return `${hours}${minutes}${seconds}`;
+};

--- a/packages/client/libs/timeago.ts
+++ b/packages/client/libs/timeago.ts
@@ -1,0 +1,24 @@
+import { register, format as timeagoFormat } from 'timeago.js';
+
+export const koreanLocaleFunc = (_, index: number): [string, string] => {
+  return [
+    ['방금', '곧'],
+    ['%s초 전', '%s초 후'],
+    ['1분 전', '1분 후'],
+    ['%s분 전', '%s분 후'],
+    ['1시간 전', '1시간 후'],
+    ['%s시간 전', '%s시간 후'],
+    ['1일 전', '1일 후'],
+    ['%s일 전', '%s일 후'],
+    ['1주일 전', '1주일 후'],
+    ['%s주일 전', '%s주일 후'],
+    ['1개월 전', '1개월 후'],
+    ['%s개월 전', '%s개월 후'],
+    ['1년 전', '1년 후'],
+    ['%s년 전', '%s년 후'],
+  ][index] as [string, string];
+};
+
+register('ko', koreanLocaleFunc);
+
+export const format = timeagoFormat;

--- a/packages/client/next.config.js
+++ b/packages/client/next.config.js
@@ -1,0 +1,9 @@
+// import { config } from 'dotenv';
+const { config } = require('dotenv');
+config();
+
+module.exports = {
+  env: {
+    API_URL_HOST: process.env.API_URL_HOST,
+  },
+};

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1023,6 +1023,14 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-query": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@types/react-query/-/react-query-0.3.2.tgz",
+      "integrity": "sha512-TD0DN2NjmJ91h34dWV4HEl6anpTyh5jwm08/9ohsslqrWNTUsYPeXwAUWUaAESFpPKHaE0WPqI4j3BGPTi9Ncg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.3.tgz",
@@ -2602,6 +2610,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -4022,6 +4035,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-unfetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz",
+      "integrity": "sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==",
+      "requires": {
+        "node-fetch": "^2.2.0",
+        "unfetch": "^4.0.0"
+      }
     },
     "jest-worker": {
       "version": "24.9.0",
@@ -5768,6 +5790,14 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+    },
+    "react-query": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-0.3.15.tgz",
+      "integrity": "sha512-FhS66AtdQ63GIgH9UPQSVdHkmcbFzbvm5zKhG9vg3+me6MqG5VHX6lE3y8hovEG2IXsNUw7zPT0qb5LUAlS9xg==",
+      "requires": {
+        "@types/react-query": "^0.3.0"
+      }
     },
     "react-transition-group": {
       "version": "4.3.0",

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -4522,6 +4522,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6662,6 +6667,11 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "timeago.js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.1.tgz",
+      "integrity": "sha512-ePzZuMoJqUc44hJbUYtY1qtzU7IammxooDCcFKogLkS5Nj+iCabR0ZlmNOFX8Dm1r5EpvR5q/PotOJli/mEPew=="
     },
     "timers-browserify": {
       "version": "2.0.11",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,9 +10,12 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.6.0",
+    "dotenv": "^8.2.0",
+    "isomorphic-unfetch": "^3.0.0",
     "next": "9.1.3",
     "react": "16.11.0",
     "react-dom": "16.11.0",
+    "react-query": "^0.3.15",
     "styled-components": "^4.4.1"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,11 +12,13 @@
     "@material-ui/core": "^4.6.0",
     "dotenv": "^8.2.0",
     "isomorphic-unfetch": "^3.0.0",
+    "moment": "^2.24.0",
     "next": "9.1.3",
     "react": "16.11.0",
     "react-dom": "16.11.0",
     "react-query": "^0.3.15",
-    "styled-components": "^4.4.1"
+    "styled-components": "^4.4.1",
+    "timeago.js": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^12.12.7",

--- a/packages/client/svgs/SearchSVG/index.tsx
+++ b/packages/client/svgs/SearchSVG/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const SvgComponent = props => (
-  <svg width={props.width} height={props.height} {...props}>
+  <svg width={props.width} height={props.height} viewBox="0 0 24 24" {...props}>
     <path
       d="M14.785 14h-.745l-.264-.27a6.706 6.706 0 001.48-4.23A6.322 6.322 0 009.128 3 6.322 6.322 0 003 9.5 6.322 6.322 0 009.128 16a5.9 5.9 0 003.988-1.57l.255.28v.79l4.714 4.99L19.49 19zm-5.657 0a4.371 4.371 0 01-4.242-4.5A4.371 4.371 0 019.128 5a4.371 4.371 0 014.243 4.5A4.371 4.371 0 019.128 14z"
       fill="#fff"

--- a/packages/client/views/Hotlist/hooks.ts
+++ b/packages/client/views/Hotlist/hooks.ts
@@ -1,0 +1,10 @@
+import { useQuery } from 'react-query';
+import { fetch } from '../../libs/fetch';
+
+export const useHotlistVideos = (page: number, period: string) => {
+  return useQuery(['hotlistVideos', { page, period }], () =>
+    fetch(
+      `${process.env.API_URL_HOST}/videos?page=${page}&sort=popular&period=${period}`,
+    ),
+  );
+};

--- a/packages/client/views/Hotlist/index.tsx
+++ b/packages/client/views/Hotlist/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 
+import { hotlistFilters } from '../../constants';
+
 import * as S from './styles';
 import HotlistSVG from '../../svgs/HotlistSVG/';
 import Layout from '../../components/Layout';
@@ -198,10 +200,12 @@ const videos = [
 ];
 
 const Hotlist: React.FunctionComponent = () => {
-  const [activeFilter, setActiveFilter] = useState('일주일');
+  const [activeFilterValue, setActiveFilterValue] = useState(
+    hotlistFilters[0].value,
+  );
 
-  const handleFilterClick = filter => {
-    setActiveFilter(filter);
+  const handleFilterClick = value => {
+    setActiveFilterValue(value);
   };
 
   return (
@@ -213,8 +217,8 @@ const Hotlist: React.FunctionComponent = () => {
         </S.Title>
 
         <S.StyledFilters
-          filters={['일주일', '한달', '일년', '전체']}
-          activeFilter={activeFilter}
+          filters={hotlistFilters}
+          activeValue={activeFilterValue}
           onClick={handleFilterClick}
         />
 

--- a/packages/client/views/Hotlist/index.tsx
+++ b/packages/client/views/Hotlist/index.tsx
@@ -4,204 +4,21 @@ import Grid from '@material-ui/core/Grid';
 import { hotlistFilters } from '../../constants';
 
 import * as S from './styles';
+
+import { useHotlistVideos } from './hooks';
+
 import HotlistSVG from '../../svgs/HotlistSVG/';
 import Layout from '../../components/Layout';
 import VideoItem from '../../components/VideoItem';
 
-const videos = [
-  {
-    id: 1,
-    title: 'Redux-Saga - 제너레이터, 사이드이펙트, 채널',
-    description: '',
-    like: 281,
-    hit: 231,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/UxpREAHZ7Ck/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLDJAgGKZcymeoayYPi8rz8yhBUIrA',
-    playtime: '10:44',
-    user: {
-      username: '알렉스 권',
-      avatar: 'https://miro.medium.com/max/3150/1*n4VB9UbNNoB78-vGIhulag.jpeg',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 2,
-    title: 'FEconf 2019 Promotional Video',
-    description: '',
-    like: 281,
-    hit: 2931,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/F7fwB90JdXI/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLDjh0ESIVV92Oy0V7IXdJqZNDaXyQ',
-    playtime: '15:01',
-    user: {
-      username: 'shinji_every',
-      avatar:
-        'https://scontent-icn1-1.cdninstagram.com/vp/27c0cc1278a9631e8a780b1ece362b9e/5E699B53/t51.2885-19/s320x320/19535398_333458263754258_1048506181011636224_a.jpg?_nc_ht=scontent-icn1-1.cdninstagram.com',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 3,
-    title: 'TC39 스펙에 대한 주관적 참견 시점 - 서재원',
-    description: '',
-    like: 0,
-    hit: 931,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/x4jaA3MMGSQ/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAINSBLetcIZoUAb-VmeQwM6xa9GA',
-    playtime: '32:44',
-    user: {
-      username: '리채니',
-      avatar:
-        'https://scontent-icn1-1.cdninstagram.com/vp/36d31a1ed72020cf7aa877cee7ada28e/5E53CEE5/t51.2885-19/s320x320/70138700_424910224803642_8758881047598333952_n.jpg?_nc_ht=scontent-icn1-1.cdninstagram.com',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 4,
-    title: 'React Component와 D3 Object를 유기적으로 연결하는 전략 - 박승현',
-    description: '',
-    like: 0,
-    hit: 482,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/x4jaA3MMGSQ/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAINSBLetcIZoUAb-VmeQwM6xa9GA',
-    playtime: '32:44',
-    user: {
-      username: 'daonno1',
-      avatar:
-        'https://scontent-icn1-1.cdninstagram.com/vp/252dd980b9e13a462042e3e02e3090b1/5E516BC3/t51.2885-19/s320x320/66999433_729979980782225_6027446340294803456_n.jpg?_nc_ht=scontent-icn1-1.cdninstagram.com',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 5,
-    title: 'JAVA 객체 지향 프로그래밍 - 6. static',
-    description: '',
-    like: 0,
-    hit: 482,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/hvTuZshZvIo/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAfNw4-kK6P_a3T92y5uViXTwsmNA',
-    playtime: '31:44',
-    user: {
-      username: '생활코딩',
-      avatar:
-        'https://yt3.ggpht.com/a/AGF-l7_-fY-v2l9ftQhWqvA7cPPNqJ_C8YzAqtDEeg=s288-c-k-c0xffffffff-no-rj-mo',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 6,
-    title: 'Redux-Saga - 제너레이터, 사이드이펙트, 채널',
-    description: '',
-    like: 281,
-    hit: 231,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/UxpREAHZ7Ck/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLDJAgGKZcymeoayYPi8rz8yhBUIrA',
-    playtime: '10:44',
-    user: {
-      username: '알렉스 권',
-      avatar: 'https://miro.medium.com/max/3150/1*n4VB9UbNNoB78-vGIhulag.jpeg',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 7,
-    title: 'FEconf 2019 Promotional Video',
-    description: '',
-    like: 281,
-    hit: 2931,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/F7fwB90JdXI/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLDjh0ESIVV92Oy0V7IXdJqZNDaXyQ',
-    playtime: '15:01',
-    user: {
-      username: 'shinji_every',
-      avatar:
-        'https://scontent-icn1-1.cdninstagram.com/vp/27c0cc1278a9631e8a780b1ece362b9e/5E699B53/t51.2885-19/s320x320/19535398_333458263754258_1048506181011636224_a.jpg?_nc_ht=scontent-icn1-1.cdninstagram.com',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 8,
-    title: 'TC39 스펙에 대한 주관적 참견 시점 - 서재원',
-    description: '',
-    like: 0,
-    hit: 931,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/x4jaA3MMGSQ/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAINSBLetcIZoUAb-VmeQwM6xa9GA',
-    playtime: '32:44',
-    user: {
-      username: '리채니',
-      avatar:
-        'https://scontent-icn1-1.cdninstagram.com/vp/36d31a1ed72020cf7aa877cee7ada28e/5E53CEE5/t51.2885-19/s320x320/70138700_424910224803642_8758881047598333952_n.jpg?_nc_ht=scontent-icn1-1.cdninstagram.com',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 9,
-    title: 'React Component와 D3 Object를 유기적으로 연결하는 전략 - 박승현',
-    description: '',
-    like: 0,
-    hit: 482,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/x4jaA3MMGSQ/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAINSBLetcIZoUAb-VmeQwM6xa9GA',
-    playtime: '32:44',
-    user: {
-      username: 'daonno1',
-      avatar:
-        'https://scontent-icn1-1.cdninstagram.com/vp/252dd980b9e13a462042e3e02e3090b1/5E516BC3/t51.2885-19/s320x320/66999433_729979980782225_6027446340294803456_n.jpg?_nc_ht=scontent-icn1-1.cdninstagram.com',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-  {
-    id: 10,
-    title: 'JAVA 객체 지향 프로그래밍 - 6. static',
-    description: '',
-    like: 0,
-    hit: 482,
-    sourceUrl: '',
-    thumbnail:
-      'https://i.ytimg.com/vi/hvTuZshZvIo/hqdefault.jpg?sqp=-oaymwEZCNACELwBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAfNw4-kK6P_a3T92y5uViXTwsmNA',
-    playtime: '31:44',
-    user: {
-      username: '생활코딩',
-      avatar:
-        'https://yt3.ggpht.com/a/AGF-l7_-fY-v2l9ftQhWqvA7cPPNqJ_C8YzAqtDEeg=s288-c-k-c0xffffffff-no-rj-mo',
-    },
-    tags: [],
-    likedUsers: [],
-    comments: [],
-  },
-];
-
 const Hotlist: React.FunctionComponent = () => {
   const [activeFilterValue, setActiveFilterValue] = useState(
     hotlistFilters[0].value,
+  );
+
+  const { data: videos, isLoading, error } = useHotlistVideos(
+    1,
+    activeFilterValue,
   );
 
   const handleFilterClick = value => {
@@ -223,13 +40,15 @@ const Hotlist: React.FunctionComponent = () => {
         />
 
         <S.ContainerGrid container spacing={2}>
-          {videos.map(video => {
-            return (
-              <Grid key={video.id} item xs={12} md={3}>
-                <VideoItem {...video} />
-              </Grid>
-            );
-          })}
+          {!isLoading && !error && videos
+            ? videos.map(video => {
+                return (
+                  <Grid key={video.id} item xs={12} md={3}>
+                    <VideoItem {...video} />
+                  </Grid>
+                );
+              })
+            : null}
         </S.ContainerGrid>
       </S.Container>
     </Layout>

--- a/packages/client/views/Latest/index.tsx
+++ b/packages/client/views/Latest/index.tsx
@@ -207,13 +207,13 @@ const Latest: React.FunctionComponent = () => {
         </S.Title>
 
         <S.ContainerGrid container spacing={2}>
-          {videos.map(video => {
+          {/* {videos.map(video => {
             return (
               <Grid key={video.id} item xs={12} md={3}>
                 <VideoItem {...video} />
               </Grid>
             );
-          })}
+          })} */}
         </S.ContainerGrid>
       </S.Container>
     </Layout>

--- a/packages/server/.env.dummy
+++ b/packages/server/.env.dummy
@@ -8,3 +8,5 @@ TYPEORM_SYNCHRONIZE=true
 TYPEORM_LOGGING=true
 
 TYPEORM_ENTITIES=dist/typeorm/src/entity/*.entity.js
+
+CORS_ALLOWED_ORIGINS="http://localhost:3000, https://wedev.tv"

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -6964,6 +6964,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "@nestjs/core": "^6.7.2",
     "@nestjs/platform-express": "^6.7.2",
     "@nestjs/typeorm": "^6.2.0",
+    "moment": "^2.24.0",
     "mysql": "^2.17.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.0",

--- a/packages/server/src/common/pipes/get-videos.pipe/dto.ts
+++ b/packages/server/src/common/pipes/get-videos.pipe/dto.ts
@@ -1,6 +1,7 @@
 export class GetVideosPipeDto {
   public constructor(
-    public readonly page: string,
-    public readonly sort: string,
+    public readonly page?: string,
+    public readonly sort?: string,
+    public readonly period?: string,
   ) {}
 }

--- a/packages/server/src/common/pipes/get-videos.pipe/index.ts
+++ b/packages/server/src/common/pipes/get-videos.pipe/index.ts
@@ -1,13 +1,9 @@
-import {
-  PipeTransform,
-  ArgumentMetadata,
-  Injectable,
-  BadRequestException,
-} from '@nestjs/common';
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
 import { GetVideosPipeDto } from './dto';
-import { LATEST, POPULAR } from 'src/video/constants';
+import { LATEST, POPULAR, PERIODS } from 'src/video/constants';
+import { VideosQueryDto } from 'src/video/dto/videos-query.dto';
 
-const defaultValue = {
+const defaultValue: VideosQueryDto = {
   page: 1,
   sort: POPULAR,
 };
@@ -15,7 +11,7 @@ const defaultValue = {
 @Injectable()
 export class GetVideosPipe implements PipeTransform {
   public async transform(getVideosPipeDto: GetVideosPipeDto) {
-    const { page, sort } = getVideosPipeDto;
+    const { page, sort, period } = getVideosPipeDto;
 
     const value = defaultValue;
 
@@ -25,20 +21,49 @@ export class GetVideosPipe implements PipeTransform {
 
     value.page = parseInt(page, 10);
     value.sort = sort;
+    value.period = period;
 
     return value;
   }
 
-  private validateGetVideosPipeDto({ page, sort }: GetVideosPipeDto) {
-    return page && this.validatePage(page) && sort && this.validateSort(sort);
+  private validateGetVideosPipeDto({ page, sort, period }: GetVideosPipeDto) {
+    return (
+      this.validatePage(page) &&
+      this.validateSort(sort) &&
+      this.validatePeriod(period, sort)
+    );
   }
 
   private validatePage(page: string) {
     const parsedPage = parseInt(page, 10);
-    return !isNaN(parsedPage) && parsedPage > 0;
+    return page && !isNaN(parsedPage) && parsedPage > 0;
   }
 
   private validateSort(sort: string) {
-    return sort === LATEST || sort === POPULAR;
+    return sort && (sort === LATEST || sort === POPULAR);
+  }
+
+  private validatePeriod(period: string, sort: string) {
+    let isValid = true;
+
+    if (sort === POPULAR && !period) {
+      isValid = false;
+    }
+
+    if (
+      sort === POPULAR &&
+      period !== PERIODS.week &&
+      period !== PERIODS.month &&
+      period !== PERIODS.year &&
+      period !== PERIODS.all
+    ) {
+      isValid = false;
+    }
+
+    if (sort !== POPULAR && period) {
+      isValid = false;
+    }
+
+    return isValid;
   }
 }

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -3,6 +3,9 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({
+    origin: process.env.CORS_ALLOWED_ORIGINS.split(','),
+  });
   await app.listen(4000);
 }
 bootstrap();

--- a/packages/server/src/video/constants.ts
+++ b/packages/server/src/video/constants.ts
@@ -1,4 +1,19 @@
 export const LATEST = 'latest';
 export const POPULAR = 'popular';
 
+export const PERIODS = {
+  week: 'week',
+  month: 'month',
+  year: 'year',
+  all: 'all',
+};
+
+export const MOMENT_SUBTRACT_FROM_NOW_ARGUMENTS = {
+  week: [7, 'days'],
+  month: [1, 'months'],
+  year: [1, 'years'],
+};
+
+export const MOMENT_DATETIME_FORMAT = 'YYYY-MM-DD HH:MM:ss';
+
 export const VIDEO_ITEMS_PER_PAGE = 20;

--- a/packages/server/src/video/dto/videos-query.dto.ts
+++ b/packages/server/src/video/dto/videos-query.dto.ts
@@ -1,6 +1,7 @@
 export class VideosQueryDto {
   public constructor(
-    public readonly page: number,
-    public readonly sort: string,
+    public page: number,
+    public sort: string,
+    public period?: string,
   ) {}
 }

--- a/packages/server/src/video/video.controller.ts
+++ b/packages/server/src/video/video.controller.ts
@@ -13,10 +13,11 @@ export class VideoController {
   public async getVideos(
     @Query() videosQueryDto: VideosQueryDto,
   ): Promise<Video[]> {
-    const { page, sort } = videosQueryDto;
+    const { page, sort, period } = videosQueryDto;
     return await this.videoService.findVideos({
       page,
       sort,
+      period,
     });
   }
 }

--- a/packages/server/src/video/video.service.ts
+++ b/packages/server/src/video/video.service.ts
@@ -1,9 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import * as moment from 'moment';
 import { Repository } from 'typeorm';
 
 import { Video } from '../../../typeorm/src/entity/video.entity';
-import { LATEST, POPULAR, VIDEO_ITEMS_PER_PAGE } from './constants';
+import {
+  LATEST,
+  POPULAR,
+  VIDEO_ITEMS_PER_PAGE,
+  PERIODS,
+  MOMENT_SUBTRACT_FROM_NOW_ARGUMENTS,
+  MOMENT_DATETIME_FORMAT,
+} from './constants';
 import { VideosQueryDto } from './dto/videos-query.dto';
 
 @Injectable()
@@ -14,32 +22,32 @@ export class VideoService {
   ) {}
 
   public async findVideos(videosQueryDto: VideosQueryDto): Promise<Video[]> {
-    const { page, sort } = videosQueryDto;
+    const { page, sort, period } = videosQueryDto;
 
     const offset = (page - 1) * VIDEO_ITEMS_PER_PAGE;
 
     const qb = this.videoRepository
       .createQueryBuilder()
+      .leftJoin('Video.user', 'User')
+      .select('Video')
+      .addSelect(['User.id', 'User.username', 'User.avatar'])
       .limit(VIDEO_ITEMS_PER_PAGE)
       .offset(offset);
 
     if (sort === LATEST) {
-      return await qb
-        .leftJoin('Video.user', 'User')
-        .select('Video')
-        .addSelect(['User.id', 'User.username', 'User.avatar'])
-        .orderBy('Video_createdAt', 'DESC')
-        .getMany();
+      return await qb.orderBy('Video_createdAt', 'DESC').getMany();
     }
 
     if (sort === POPULAR) {
-      // TODO: 현재는 조회수 기준으로만 정렬하고 있습니다. 추후에 댓글 갯수, 좋아요 수, 조회 수를 종합하여 정렬합니다.
-      return await qb
-        .leftJoin('Video.user', 'User')
-        .select('Video')
-        .addSelect(['User.id', 'User.username', 'User.avatar'])
-        .orderBy('Video_hit', 'DESC')
-        .getMany();
+      if (period !== PERIODS.all) {
+        const startDatetime = moment()
+          .subtract(...MOMENT_SUBTRACT_FROM_NOW_ARGUMENTS[period])
+          .format(MOMENT_DATETIME_FORMAT);
+
+        qb.where('Video.createdAt > :startDatetime', { startDatetime });
+      }
+
+      return await qb.orderBy('Video_popularity', 'DESC').getMany();
     }
   }
 }

--- a/packages/typeorm/src/entity/comment.entity.ts
+++ b/packages/typeorm/src/entity/comment.entity.ts
@@ -6,6 +6,7 @@ import {
   JoinColumn,
   ManyToMany,
   BeforeInsert,
+  BeforeUpdate,
 } from 'typeorm';
 
 import { Base } from './base.entity';
@@ -93,6 +94,7 @@ export class Comment extends Base {
   public children: Comment[];
 
   @BeforeInsert()
+  @BeforeUpdate()
   public updatePopularity() {
     this.popularity =
       this.childrenCount * popularityWeight.childrenCount +

--- a/packages/typeorm/src/entity/video.entity.ts
+++ b/packages/typeorm/src/entity/video.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   JoinTable,
   BeforeInsert,
+  BeforeUpdate,
 } from 'typeorm';
 
 import { Base } from './base.entity';
@@ -134,6 +135,7 @@ export class Video extends Base {
   public comments: Comment;
 
   @BeforeInsert()
+  @BeforeUpdate()
   public updatePopularity() {
     this.popularity =
       this.likedUsersCount * popularityWeight.likedUsersCount +


### PR DESCRIPTION
[server]
- 영상 리스트가 popular 순으로 정렬될 때, period query를 사용하여 week, month, year, all 단위로 필터링 할 수 있습니다.
- cors 옵션을 활성화 했습니다. whiltelist origin 항목은 .env의 CORS_ALLOWED_ORIGINS 항목으로 관리합니다.

[client]
- 핫리스트 페이지에서 api를 활용하여 데이터를 불러옵니다. 이 때, 간결한 interface와 caching 기능을 제공하는 react-query 모듈을 사용했습니다.
- 기간 필터링을 누를 때마다 새로운 쿼리 내용으로 요청을 생성합니다.