### PR TITLE
인기 태그 UI 및 API 구현

### DIFF
--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -8,6 +8,7 @@ export const EVENT = {
 export const LEFT = 'left';
 export const TOP = 'top';
 export const PERSISTENT = 'persistent';
+export const TAGS_PER_PAGE = 24;
 
 export const routePath = {
   tags: '/tags',

--- a/packages/client/libs/chunkList.ts
+++ b/packages/client/libs/chunkList.ts
@@ -1,5 +1,5 @@
-export const chunkVideoList = (videos, itemsPerChunk) => {
-  return videos.reduce((acc, next, index) => {
+export const chunkList = (list, itemsPerChunk: number) => {
+  return list.reduce((acc, next, index) => {
     const chunkIndex = Math.floor(index / itemsPerChunk);
 
     if (!acc[chunkIndex]) {

--- a/packages/client/views/TagList/hooks.ts
+++ b/packages/client/views/TagList/hooks.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import { useQuery, Action } from 'react-fetching-library';
+import { TAGS_PER_PAGE } from '../../constants';
+
+export const createTagListAction: Action = (page: number) => ({
+  method: 'GET',
+  endpoint: `${process.env.API_URL_HOST}/tags?page=${page}`,
+});
+
+export const useTags = (page: number) => {
+  const [tags, setTags] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
+
+  const action = createTagListAction(page);
+  const { payload } = useQuery(action);
+
+  useEffect(() => {
+    if (payload) {
+      setHasMore(payload.length >= TAGS_PER_PAGE);
+      setTags([...tags, ...payload]);
+    }
+  }, [payload]);
+
+  return { tags, hasMore };
+};

--- a/packages/client/views/TagList/index.tsx
+++ b/packages/client/views/TagList/index.tsx
@@ -1,95 +1,63 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 
 import * as S from './styles';
 import Layout from '../../components/Layout';
+import { useTags } from './hooks';
+import CircularProgress from '../../components/CircularProgress';
+import { Tag } from './interface/tag';
+import { chunkList } from '../../libs/chunkList';
+
+const getOneTag = (tag: Tag) => {
+  const numberWithCommas = (x: number) => {
+    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  return (
+    <Grid key={tag.id} item xs={6} md={3}>
+      <S.Tag>
+        <S.TagTitle>{tag.name}</S.TagTitle>
+        <S.TagCount>{numberWithCommas(tag.videosCount)}</S.TagCount>
+      </S.Tag>
+    </Grid>
+  );
+};
+
+const getOneLineOfTags = (tags: Tag[], index: number) => {
+  return (
+    <S.ContainerGrid key={index} container spacing={2} justify={'flex-start'}>
+      {tags.map(getOneTag)}
+    </S.ContainerGrid>
+  );
+};
+
+const getTagList = (tags: Tag[]) => {
+  const chunckedTags = chunkList(tags, 4);
+  return <>{chunckedTags.map(getOneLineOfTags)}</>;
+};
 
 const TagList: React.FunctionComponent = () => {
+  const [page, setPage] = useState(1);
+
+  const { tags, hasMore } = useTags(page);
+
+  const handlePageChange = () => {
+    setPage(page + 1);
+  };
+
   return (
     <Layout>
       <S.TagList>
-        <S.ContainerGrid container spacing={0} justify={'center'}>
-          <Grid item xs={12} md={12}>
-            <S.ContainerGrid container spacing={2} justify={'center'}>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-            </S.ContainerGrid>
-
-            <S.ContainerGrid container spacing={2} justify={'center'}>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-            </S.ContainerGrid>
-
-            <S.ContainerGrid container spacing={2} justify={'center'}>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-              <Grid item xs={6} md={2}>
-                <S.Tag>
-                  <S.TagTitle>python</S.TagTitle>
-                  <S.TagCount>2,292</S.TagCount>
-                </S.Tag>
-              </Grid>
-            </S.ContainerGrid>
+        <S.ContainerGrid container spacing={0} justify="center">
+          <Grid item xs={12} md={8}>
+            <S.StyledInfiniteScroll
+              dataLength={tags.length}
+              next={handlePageChange}
+              hasMore={hasMore}
+              loader={<CircularProgress size={28} thickness={4.5} />}
+            >
+              {getTagList(tags)}
+            </S.StyledInfiniteScroll>
           </Grid>
         </S.ContainerGrid>
       </S.TagList>

--- a/packages/client/views/TagList/interface/tag.ts
+++ b/packages/client/views/TagList/interface/tag.ts
@@ -1,0 +1,6 @@
+export interface Tag {
+  readonly id: number;
+  readonly name: string;
+  readonly status: boolean;
+  readonly videosCount: number;
+}

--- a/packages/client/views/TagList/styles.tsx
+++ b/packages/client/views/TagList/styles.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import MaterialGrid from '@material-ui/core/Grid';
 
 import { BREAKPOINT, fontWeight } from '../../constants';
+import InfiniteScroll from 'react-infinite-scroll-component';
 
 /* window 의 넓이에 따라 변화하는 spacing을 정의해주기 위해 사용됨*/
 export const ContainerGrid = styled(MaterialGrid)`
@@ -50,4 +51,12 @@ export const TagTitle = styled.div`
 export const TagCount = styled.div`
   font-size: 1.6rem;
   font-weight: ${fontWeight.regular};
+`;
+
+export const StyledInfiniteScroll = styled(InfiniteScroll)`
+  height: auto;
+  overflow: visible !important;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;

--- a/packages/client/views/User/index.tsx
+++ b/packages/client/views/User/index.tsx
@@ -7,7 +7,7 @@ import Layout from '../../components/Layout';
 import UserProfile from '../../components/UserProfile';
 import VideoItem from '../../components/VideoItem';
 import Filters from '../../components/Filters';
-import { chunkVideoList } from '../../libs/videoList';
+import { chunkList } from '../../libs/chunkList';
 
 const videos = [
   {
@@ -195,7 +195,7 @@ const videos = [
 ];
 
 const User = () => {
-  const videoChunks = chunkVideoList(videos, 3);
+  const videoChunks = chunkList(videos, 3);
 
   return (
     <Layout drawer={false}>

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -3,9 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './user/user.module';
 import { VideoModule } from './video/video.module';
 import { WebhookModule } from './webhook/webhook.module';
-
+import { TagModule } from './tag/tag.module';
 @Module({
-  imports: [TypeOrmModule.forRoot(), WebhookModule, UserModule, VideoModule],
+  imports: [
+    TypeOrmModule.forRoot(),
+    WebhookModule,
+    UserModule,
+    VideoModule,
+    TagModule,
+  ],
   controllers: [],
   providers: [],
 })

--- a/packages/server/src/common/pipes/page-parser/page-parser.pipe.ts
+++ b/packages/server/src/common/pipes/page-parser/page-parser.pipe.ts
@@ -1,0 +1,19 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class PageParserPipe implements PipeTransform {
+  public async transform(page: string) {
+    if (!this.validate(page)) {
+      throw new BadRequestException('Validation failed');
+    }
+
+    const transformedPage = Number(page);
+    return transformedPage;
+  }
+
+  private validate(page: string) {
+    const numberCheckRegex = /^[0-9]*$/gm;
+
+    return page.match(numberCheckRegex);
+  }
+}

--- a/packages/server/src/tag/constants.ts
+++ b/packages/server/src/tag/constants.ts
@@ -1,0 +1,1 @@
+export const TAGS_PER_PAGE = 24;

--- a/packages/server/src/tag/dto/index.ts
+++ b/packages/server/src/tag/dto/index.ts
@@ -1,0 +1,1 @@
+export { TagsResponseDto } from './tags-response.dto';

--- a/packages/server/src/tag/dto/tags-response.dto.ts
+++ b/packages/server/src/tag/dto/tags-response.dto.ts
@@ -1,0 +1,15 @@
+import { Tag } from '../../../../typeorm/src/entity/tag.entity';
+
+export class TagsResponseDto {
+  public constructor(tag: Tag) {
+    this.id = tag.id;
+    this.name = tag.name;
+    this.status = tag.status;
+    this.videosCount = tag.videosCount;
+  }
+
+  public readonly id: number;
+  public readonly name: string;
+  public readonly status: number;
+  public readonly videosCount: number;
+}

--- a/packages/server/src/tag/tag.controller.ts
+++ b/packages/server/src/tag/tag.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query, UsePipes } from '@nestjs/common';
+import { TagService } from './tag.service';
+import { TagsResponseDto } from './dto';
+import { PageParserPipe } from '../common/pipes/page-parser/page-parser.pipe';
+
+@Controller('tags')
+export class TagController {
+  public constructor(private readonly tagService: TagService) {}
+
+  @Get('/')
+  @UsePipes(PageParserPipe)
+  public async getHotTags(
+    @Query('page') page: number,
+  ): Promise<TagsResponseDto[]> {
+    const Tags = await this.tagService.findHotTags(page);
+    return Tags.map(tag => new TagsResponseDto(tag));
+  }
+}

--- a/packages/server/src/tag/tag.module.ts
+++ b/packages/server/src/tag/tag.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { Tag } from '../../../typeorm/src/entity/tag.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TagController } from './tag.controller';
+import { TagService } from './tag.service';
+@Module({
+  imports: [TypeOrmModule.forFeature([Tag])],
+  providers: [TagService],
+  controllers: [TagController],
+})
+export class TagModule {}

--- a/packages/server/src/tag/tag.service.ts
+++ b/packages/server/src/tag/tag.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tag } from '../../../typeorm/src/entity/tag.entity';
+import { TAGS_PER_PAGE } from './constants';
+
+@Injectable()
+export class TagService {
+  public constructor(
+    @InjectRepository(Tag)
+    private readonly tagRepository: Repository<Tag>,
+  ) {}
+
+  public async findHotTags(page: number): Promise<Tag[]> {
+    const offset = (page - 1) * TAGS_PER_PAGE;
+
+    return await this.tagRepository.find({
+      order: {
+        videosCount: 'DESC',
+      },
+      skip: offset,
+      take: TAGS_PER_PAGE,
+    });
+  }
+}


### PR DESCRIPTION
## 작업 내용

페이지네이션을 통해 태그의 목록을 videoCounts를 우선순위로 가져온다.

server
api는 localhost:4000/tags?page=1를 endpoint로 작성하였다. (지혜님과 다시 의논해서 수정해야함)
page는 url의 query를 통해 전달되는데, validation을 위해 page-parser.pipe를 작성하였다.

client
taglist 컴포넌트에서 page를 state로 관리하여 Pagination을 수행한다.
가독성을 위해 태그를 만들어주는 함수, 한 줄의 태그를 만들어주는 함수, 모든 태그를 만들어주는 함수를 분리하였다. 

## 실행 방법
실행 후 localhost:3000/tags 에 접속하여 결과를 확인한다.

## 결과 첨부
![실행화면2](https://user-images.githubusercontent.com/41494099/69909766-60f11c80-1443-11ea-872d-fffa23c48b70.gif)